### PR TITLE
`cargo update -p proc-macro2` to fix build with nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Fixes

    $ cargo build
    error[E0635]: unknown feature `proc_macro_span_shrink`
      --> /home/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.51/src/lib.rs:92:30
       |
    92 |     feature(proc_macro_span, proc_macro_span_shrink)
       |                              ^^^^^^^^^^^^^^^^^^^^^^

    For more information about this error, try `rustc --explain E0635`.
    error: could not compile `proc-macro2` (lib) due to previous error